### PR TITLE
Add confirmation popup and fix system mode bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,46 @@
 
 **For Firefox version > 95.**
 
+**Note:** This add-on only affects websites that support both dark and light themes using standard web technology.  
+If a website doesn’t support dark mode, this extension cannot make it dark.
+
+Think of it like telling websites: “Please be dark now.”  
+If the website knows how to respond, it will. If not, it stays the same.
+
 ## Minimal add-on
 
 This is the simplest possible add-on with the least possible permissions.
 
-Clicking the add-on action in your toolbar cycles the color scheme preference _for browser content_, between the following 4 values:
+Clicking the add-on action in your toolbar cycles the color scheme preference _for browser content_, between the following values:
+
 1. dark colors
 2. light colors
-3. inherit browser colors (dark or light)
-4. inherit system colors (dark or light)
+3. inherit system colors (dark or light)
 
-You can enable or disable values in the cycle from the add-on content.
+You can enable or disable values in the cycle from the add-on content settings.
+
+A small popup confirms which mode was selected. It appears briefly after clicking and closes automatically.
 
 ## Website support
 
-This add-on relies on the fact that websites have their own proper stylesheets for dark and light modes, for example [DuckDuckGo](https://duckduckgo.com/).<br>
-An increasing number of websites now offer light and dark schemes, though you may need to select a specific option to inherit your browser’s colors, e.g. google, github, stackoverflow, and many more.
+This add-on relies on the fact that websites have their own proper stylesheets for dark and light modes, for example [DuckDuckGo](https://duckduckgo.com/).  
+An increasing number of websites now offer light and dark schemes, though you may need to select a specific option to inherit your browser’s colors, e.g. Google, GitHub, StackOverflow, and many more.
 
-If you want to add your own dark mode to other websites, you can use user style sheet addons such as e.g. Stylus. Then you can wrap the CSS in a [`prefers-color-scheme` media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) so it responds to this add-on’s toggle. For example:
+If you want to add your own dark mode to other websites, you can use user style sheet add-ons such as Stylus. Then you can wrap the CSS in a [`prefers-color-scheme` media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) so it responds to this add-on’s toggle. For example:
 
 ```css
 @media (prefers-color-scheme: dark) {
-	/* CSS that ony applies to dark mode */
-	body { background: black; color:  #ddd; }
+  body {
+    background: black;
+    color: #ddd;
+  }
 }
 
 @media (prefers-color-scheme: light) {
-	/* CSS that ony applies to light mode */
-	body { background: white; color: black; }
+  body {
+    background: white;
+    color: black;
+  }
 }
 ```
 
@@ -39,4 +51,11 @@ If you want to add your own dark mode to other websites, you can use user style 
 
 https://addons.mozilla.org/en-US/firefox/addon/toggle-dark-mode/
 
+## Credits
+
 Sun, Moon, and Solar Eclipse icons by [MarkieAnn Packer from the Noun Project](https://thenounproject.com/MarkieAnn) (under CCBY2.0).
+
+## Contributors
+
+Original author: [Cimbali](https://github.com/Cimbali)  
+Additional UI and logic improvements by [superkikim](https://github.com/superkikim)

--- a/background.js
+++ b/background.js
@@ -1,12 +1,12 @@
+// Added by GitHub user superkikim: notification popup after theme toggle.
+
 'use strict';
 
 const default_color_schemes = {
 	dark: true,
 	light: true,
-	system: false,
-	browser: false,
+	system: false
 }
-
 const color_schemes = [
 	"dark",
 	"light"
@@ -20,7 +20,7 @@ function detectDarkScheme() {
 
 function updatePrefs({ include }) {
 	const value = color_schemes[selected_scheme]
-	color_schemes.splice(0, color_schemes.length, ...Object.keys(default_color_schemes).filter(scheme => include[scheme]))
+	color_schemes.splice(0, color_schemes.length, ...Object.keys(include).filter(scheme => include[scheme]));
 	updateScheme({ value })
 }
 
@@ -46,9 +46,9 @@ function updateScheme({ value }) {
 		const basic = detectDarkScheme() ? "dark" : "light";
 		selected_scheme = color_schemes.indexOf(basic);
 	}
-	// the scheme is not in the list, and we want an inherited scheme, so take the other one
+	// the scheme is not in the list, fallback to 'system'
 	if (selected_scheme < 0) {
-		selected_scheme = color_schemes.indexOf(color_schemes.includes('browser') ? 'browser' : 'system');
+		selected_scheme = color_schemes.indexOf('system');
 	}
 	// this should never happen
 	if (selected_scheme < 0) {
@@ -62,15 +62,20 @@ function cycleScheme(tabId) {
 	browser.browserSettings.overrideContentColorScheme.set({ value: color_schemes[selected_scheme] });
 }
 
+// Set the color scheme
 Promise.all([
 	browser.storage.local.get({ include: default_color_schemes }).then(updatePrefs),
 	browser.browserSettings.overrideContentColorScheme.get({}).then(updateScheme),
 ]).then(() => {
 	browser.browserSettings.overrideContentColorScheme.onChange.addListener(updateScheme);
 	browser.runtime.onMessage.addListener(updatePrefs);
-	browser.browserAction.onClicked.addListener(cycleScheme);
 }).catch(console.error);
 
+
+
+
+
+// Set default color schemes on install
 browser.runtime.onInstalled.addListener(({ reason, temporary }) => {
 	if (reason === 'install') {
 		browser.storage.local.set({ include: default_color_schemes })

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
     "96": "icons/system_96x96.png"
   },
   "browser_action": {
+    "default_popup": "popup.html",
     "browser_style": true,
     "default_icon": {
       "48": "icons/system_48x48.png",
@@ -19,18 +20,20 @@
     "default_title": "Toggle dark/light/system schemes"
   },
   "commands": {
-      "_execute_browser_action": {
-          "suggested_key": {
-              "default": "Ctrl+Shift+L"
-          }
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L"
       }
+    }
   },
   "permissions": [
     "storage",
     "browserSettings"
   ],
   "background": {
-    "scripts": ["background.js"]
+    "scripts": [
+      "background.js"
+    ]
   },
   "options_ui": {
     "page": "/options.html",

--- a/options.html
+++ b/options.html
@@ -1,37 +1,49 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Toggle light and dark content schemes</title>
+    <style>
+      body {
+        padding: 30px;
+      }
+      label {
+        display: block;
+      }
+      ul {
+        margin: 0;
+        list-style-type: none;
+      }
+      .error {
+        font-weight: bold;
+        color: darkred;
+      }
+    </style>
+  </head>
 
-<head>
-	<meta charset="utf-8">
-	<title>Toggle light and dark content schemes</title>
-<style>
-body {
-	padding: 30px;
-}
-label {
-	display: block;
-}
-ul {
-	margin: 0;
-	list-style-type: none;
-}
-.error {
-	font-weight: bold;
-	color: darkred;
-}
-</style>
-</head>
+  <body>
+    <p>Choose between which values to cycle:</p>
+    <ul>
+      <li>
+        <label><input type="checkbox" name="dark" />Forced <em>dark</em></label>
+      </li>
+      <li>
+        <label
+          ><input type="checkbox" name="light" />Forced
+          <em>light</em> scheme</label
+        >
+      </li>
+      <li>
+        <label
+          ><input type="checkbox" name="system" />Inherit
+          <em>system</em> scheme</label
+        >
+      </li>
+    </ul>
+    <p class="error" id="more-values-needed" style="display: none">
+      Settings not saved: at least 2 values are needed to cycle.
+    </p>
 
-<body>
-	<p>Choose between which values to cycle:</p>
-	<ul>
-		<li><label><input type="checkbox" name="dark">Forced <em>dark</em></label></li>
-		<li><label><input type="checkbox" name="light">Forced <em>light</em> scheme</label></li>
-		<li><label><input type="checkbox" name="system">Inherit <em>system</em> scheme</label></li>
-		<li><label><input type="checkbox" name="browser">Include <em>browser</em> scheme</label></li>
-	</ul>
-	<p class="error" id="more-values-needed" style="display: none;">Settings not saved: at least 2 values are needed to cycle.</p>
-
-	<script type="text/javascript" src="/options.js"></script>
-</body>
+    <script type="text/javascript" src="/options.js"></script>
+  </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,35 @@
+<!-- popup.html -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 10px;
+        min-width: 180px;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      li {
+        padding: 6px 10px;
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      li:hover {
+        background-color: #eee;
+      }
+      .selected::after {
+        content: " ✓";
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <ul id="mode-list"></ul>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,58 @@
+const list = document.getElementById('mode-list');
+let modes = [];
+let selected_scheme = -1;
+
+const color_schemes_labels = {
+	dark: "Dark mode",
+	light: "Light mode",
+	system: "System default"
+};
+
+function detectDarkScheme() {
+	return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+function updateSelectedScheme(value) {
+	if (value === "auto") value = "system";
+
+	selected_scheme = modes.indexOf(value);
+
+	if (selected_scheme < 0) {
+		selected_scheme = detectDarkScheme() ? modes.indexOf("dark") : modes.indexOf("light");
+	}
+	if (selected_scheme < 0) selected_scheme = 0;
+}
+
+function cycleScheme() {
+	selected_scheme = (selected_scheme + 1) % modes.length;
+	return browser.browserSettings.overrideContentColorScheme.set({
+		value: modes[selected_scheme]
+	});
+}
+
+function displayActiveMode() {
+	const current = modes[selected_scheme];
+	const label = color_schemes_labels[current] || current;
+
+	const li = document.createElement('li');
+	li.textContent = label;
+	list.appendChild(li);
+}
+
+// Main logic
+browser.storage.local.get('include').then(({ include }) => {
+	modes = Object.keys(include).filter(scheme => include[scheme]);
+
+	browser.browserSettings.overrideContentColorScheme.get({}).then(({ value }) => {
+		updateSelectedScheme(value);
+		cycleScheme().then(() => {
+			displayActiveMode();
+           	setTimeout(() => window.close(), 1000);
+		});
+	});
+});
+
+// Close on mouse leave
+document.body.addEventListener('mouseleave', () => {
+	window.close();
+});


### PR DESCRIPTION
This PR improves the usability and stability of the extension while maintaining its minimal design.

    Removed unsupported "browser" mode from cycling logic and options UI

    Fixed a bug where the extension failed when the color scheme was set to "system" (now returned as "auto" in Firefox)

    Introduced a small popup (popup.html + popup.js) to show the active mode label after each click

    Popup closes automatically after 1s or on mouse leave

    Ensured only user-enabled modes are included in the cycle

    Cleaned up background logic for better separation of concerns

    Updated README for clarity and to better reflect current Firefox behavior

All changes are isolated and backward-compatible.